### PR TITLE
docs: update language used in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,23 +6,25 @@ Fixes # (issue)
 
 # Type of change
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature or functionality (non-breaking change which adds functionality)
+- [ ] Bug fix (change which fixes an issue)
+- [ ] New feature or functionality (change which adds functionality)
 - [ ] Style (white-space, formatting, etc...)
 - [ ] Refactor (a code change that neither fixes a bug or adds a new feature)
 - [ ] Performance (a code change that improves performance)
 - [ ] Documentation (updates to documentation or READMEs)
 - [ ] Chore (any other change that doesn't affect source or test files)
+
 # Properties of change
 
 - [ ] Breaking change (this change will cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
+
 # Test plan
 
 How has this been tested?
 
 - [ ] Covered by existing tests cases
 - [ ] New test cases added
-- [ ] Local testing
+- [ ] Manual testing
 
-If part of the test plan included local testing, please provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+If part of the test plan included manual testing, please provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


### PR DESCRIPTION
Updates some of the language used on the pull request template.

* Removes the "non-breaking" wording in the top "type of change" section. This information is already collected and conflicts with the options in the next section (adding a breaking feature for example).
* Switches the use of "local" to "manual" in the test plan to avoid confusion around "Where were the tests ran" vs "How was this tested". 