### PR TITLE
Update list of our rulesets

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,12 +2,17 @@
 We offer software that makes Bazel easier to use: <https://aspect.build>.
 
 -   [Aspect CLI](https://github.com/aspect-build/aspect-cli) - correct, fast, usable: choose three
--   JavaScript
+-   Bazel rules we donated to the Linux Foundation under the bazel-contrib org:
+    -   https://github.com/topics/aspect-build
+-   Bazel rules for OS images, Containers and Docker
+    -   https://github.com/GoogleContainerTools/rules_distroless
+    -   https://github.com/chainguard-dev/rules_apko
+-   Bazel rules for JavaScript and TypeScript
     -   [rules_js](https://github.com/aspect-build/rules_js) - Bazel rules for building JavaScript programs
+    -   [rules_ts](https://github.com/aspect-build/rules_ts) - Bazel rules for [TypeScript](http://typescriptlang.org)
     -   [rules_esbuild](https://github.com/aspect-build/rules_esbuild) - Bazel rules for [esbuild](https://esbuild.github.io) JS bundler
     -   [rules_terser](https://github.com/aspect-build/rules_terser) - Bazel rules for [Terser](https://terser.org) - a JavaScript minifier
     -   [rules_swc](https://github.com/aspect-build/rules_swc) - Bazel rules for [swc](https://swc.rs)
-    -   [rules_ts](https://github.com/aspect-build/rules_ts) - Bazel rules for [TypeScript](http://typescriptlang.org)
     -   [rules_webpack](https://github.com/aspect-build/rules_webpack) - Bazel rules for [Webpack](https://webpack.js.org)
     -   [rules_rollup](https://github.com/aspect-build/rules_rollup) - Bazel rules for [Rollup](https://rollupjs.org) - a JavaScript bundler
     -   [rules_jest](https://github.com/aspect-build/rules_jest) - Bazel rules to run tests using [Jest](https://jestjs.io)
@@ -16,7 +21,6 @@ We offer software that makes Bazel easier to use: <https://aspect.build>.
 -   Python
     -   [rules_py](https://github.com/aspect-build/rules_py) - Bazel rules for running Python tools and building Python projects
 -   Utilities
-    -   [bazel-lib](https://github.com/aspect-build/bazel-lib) - Common useful rules & functions for writing custom build rules with Starlark
     -   [rules_lint](https://github.com/aspect-build/rules_lint) - Aggregator to lint/format code in most languages
 
 If you use our free software, please consider donating so we can pay our engineers who write it! https://opencollective.com/aspect-build


### PR DESCRIPTION
We have 7 under bazel-contrib now.

Supports removal of the /rules page from our docusaurus site.