### PR TITLE
fix(lychee): on non-PR runs, just fail the first step

### DIFF
--- a/.github/workflows/org-check.yaml
+++ b/.github/workflows/org-check.yaml
@@ -27,9 +27,9 @@ jobs:
           with:
               args: --user-agent "curl/8.4.0" "*.md" "docs/*.md"
               output: ${{ env.LYCHEE_OUT }}
-              fail: false
-        - name: Fail if broken links found
-          if: steps.lychee.outputs.exit_code != '0'
+              fail: github.event_name != 'pull_request'
+        - name: Comment on PR if broken links found
+          if: github.event_name == 'pull_request' && steps.lychee.outputs.exit_code != '0'
           run: |
               gh pr comment ${{ github.event.pull_request.number }} --body-file ${{ env.LYCHEE_OUT }} --edit-last --create-if-none
               exit ${{ steps.lychee.outputs.exit_code }}


### PR DESCRIPTION
We don't need the PR comment feature on main
