### PR TITLE
fix: commenting on a PR requires a token from the caller's GH repo, not the .github repo owning this workflow

### DIFF
--- a/.github/workflows/org-check.yaml
+++ b/.github/workflows/org-check.yaml
@@ -4,6 +4,9 @@ on:
   # enables reuse from other repos
   # NB: this workflow must be explicitly called from repos in this org
   workflow_call:
+    secrets:
+      CALLER_GH_TOKEN:
+        required: true
 permissions:
   pull-requests: write
   contents: read
@@ -17,7 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   check-links:
     env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.CALLER_GH_TOKEN }}
         LYCHEE_OUT: 'lychee-report.md'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Seems to be needed based on testing on https://github.com/aspect-build/rules_js/actions/runs/23507299001/job/68418557922?pr=2782